### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,8 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	# Make sure to compile files after any other files they include!
 	pip-compile --upgrade --allow-unsafe -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --upgrade -o requirements/test.txt requirements/test.in
 	pip-compile --upgrade -o requirements/ci.txt requirements/ci.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -114,7 +114,7 @@ docutils==0.18.1
     # via sphinx
 edx-django-utils==5.0.0
     # via -r requirements/test.txt
-edx-lint==5.2.2
+edx-lint==5.2.3
     # via
     #   -r requirements/dev.in
     #   -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -72,7 +72,7 @@ django-waffle==2.5.0
     #   edx-django-utils
 edx-django-utils==5.0.0
     # via -r requirements/base.txt
-edx-lint==5.2.2
+edx-lint==5.2.3
     # via -r requirements/test.in
 iniconfig==1.1.1
     # via pytest


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this https://github.com/openedx/edx-repo-health/pull/271 for new check added in edx-repo-health.

JIRA: https://2u-internal.atlassian.net/browse/BOM-3459