### PR TITLE
fix: add backend_name parameter to EventBusRoutingBackend

### DIFF
--- a/eventtracking/__init__.py
+++ b/eventtracking/__init__.py
@@ -1,3 +1,3 @@
 """A simple event tracking library"""
 
-__version__ = '2.3.0'
+__version__ = '2.3.1'

--- a/eventtracking/backends/event_bus.py
+++ b/eventtracking/backends/event_bus.py
@@ -20,6 +20,10 @@ class EventBusRoutingBackend(RoutingBackend):
     Event tracker backend for the event bus.
     """
 
+    def __init__(self, processors=None, backends=None, backend_name=''):
+        self.backend_name = backend_name
+        super().__init__(processors=processors, backends=backends)
+
     def send(self, event):
         """
         Send the tracking log event to the event bus by emitting the


### PR DESCRIPTION
### Description

This PR add the parameter `backend_name` to the `EventBusRoutingBackend` so that it can be used interchangeable with the `AsyncRoutingBackend`.