### PR TITLE
feanil/update pymongo

### DIFF
--- a/eventtracking/__init__.py
+++ b/eventtracking/__init__.py
@@ -1,3 +1,3 @@
 """A simple event tracking library"""
 
-__version__ = '3.0.0'
+__version__ = '3.0.1'

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,8 +3,7 @@
 -c constraints.txt
 
 django
-# https://pymongo.readthedocs.io/en/4.4.0/migrate-to-pymongo4.html#son-items-now-returns-dict-items-object
-pymongo>=4.0.0,<4.4.1
+pymongo>=4.0.0
 pytz
 six
 celery

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -86,7 +86,7 @@ psutil==6.1.1
     # via edx-django-utils
 pycparser==2.22
     # via cffi
-pymongo==4.4.0
+pymongo==4.10.1
     # via
     #   -r requirements/base.in
     #   edx-opaque-keys

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -266,7 +266,7 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pymongo==4.4.0
+pymongo==4.10.1
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -358,8 +358,10 @@ tzdata==2024.2
     #   -r requirements/test.txt
     #   celery
     #   kombu
-urllib3==2.3.0
-    # via requests
+urllib3==2.2.3
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   requests
 vine==5.1.0
     # via
     #   -r requirements/test.txt

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -12,5 +12,5 @@ pip==24.2
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==75.7.0
+setuptools==75.8.0
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -168,7 +168,7 @@ pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==4.4.0
+pymongo==4.10.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys


### PR DESCRIPTION
We updated to 4.x a while ago so I'm not sure why pymongo is pinned this way.  The usage in this repo are pretty minimal so I think the testing will catch any issues that crop up.