### PR TITLE
Add django 5.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest]
         python-version:
         - '3.11'
-        toxenv: [celery54-django42]
+        toxenv: [celery54-django42, celery54-django52]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,17 @@
+Change Log
+==========
+
+..
+   All enhancements and patches to eventtracking will be documented
+   in this file.  It adheres to the structure of http://keepachangelog.com/ ,
+   but in reStructuredText instead of Markdown (for ease of incorporation into
+   Sphinx documentation and the PyPI description).
+   This project adheres to Semantic Versioning (http://semver.org/).
+
+.. There should always be an "Unreleased" section for changes pending release.
+Unreleased
+----------
+
+3.3.0 - 2025-04-25
+---------------------
+* Added Support for ``django 5.2``.

--- a/eventtracking/__init__.py
+++ b/eventtracking/__init__.py
@@ -1,3 +1,3 @@
 """A simple event tracking library"""
 
-__version__ = '3.2.0'
+__version__ = '3.3.0'

--- a/eventtracking/backends/routing.py
+++ b/eventtracking/backends/routing.py
@@ -118,7 +118,7 @@ class RoutingBackend:
                     processed_event = modified_event
             except EventEmissionExit:
                 raise
-            except Exception:
+            except Exception:   # pylint: disable=broad-exception-caught
                 LOG.exception(
                     'Failed to execute processor: %s', str(processor)
                 )
@@ -142,7 +142,7 @@ class RoutingBackend:
                 LOG.info('[send_to_backends] Failed to send edx event "%s" to "%s" backend. "%s" backend has'
                          ' not been enabled, [%s]', event["name"], name, name, repr(exc)
                          )
-            except Exception:
+            except Exception:   # pylint: disable=broad-exception-caught
                 LOG.exception(
                     'Unable to send edx event "%s" to backend: %s', event["name"], name
                 )

--- a/eventtracking/backends/tests/test_routing.py
+++ b/eventtracking/backends/tests/test_routing.py
@@ -20,28 +20,28 @@ class TestRoutingBackend(TestCase):
         self.router = RoutingBackend(backends={'0': self.mock_backend})
 
     def test_non_callable_backend(self):
-        with self.assertRaisesRegexp(  # pylint: disable=deprecated-method,useless-suppression
+        with self.assertRaisesRegex(
                 ValueError, r'Backend \w+ does not have a callable "send" method.'):
             RoutingBackend(backends={
                 'a': 'b'
             })
 
     def test_backend_without_send(self):
-        with self.assertRaisesRegexp(  # pylint: disable=deprecated-method,useless-suppression
+        with self.assertRaisesRegex(
                 ValueError, r'Backend \w+ does not have a callable "send" method.'):
             RoutingBackend(backends={
                 'a': object()
             })
 
     def test_non_callable_processor(self):
-        with self.assertRaisesRegexp(  # pylint: disable=deprecated-method,useless-suppression
+        with self.assertRaisesRegex(
                 ValueError, r'Processor \w+ is not callable.'):
             RoutingBackend(processors=[
                 object()
             ])
 
     def test_non_callable_processor_simple_type(self):
-        with self.assertRaisesRegexp(  # pylint: disable=deprecated-method,useless-suppression
+        with self.assertRaisesRegex(
                 ValueError, r'Processor \w+ is not callable.'):
             RoutingBackend(processors=[
                 'b'

--- a/eventtracking/processors/tests/test_whitelist.py
+++ b/eventtracking/processors/tests/test_whitelist.py
@@ -44,7 +44,7 @@ class TestNameWhitelistProcessor(TestCase):
 
     def assert_initialization_fails(self):
         """Assert that the constructor raises the expected initialization exception"""
-        return self.assertRaisesRegexp(  # pylint: disable=deprecated-method,useless-suppression
+        return self.assertRaisesRegex(  # pylint: disable=deprecated-method,useless-suppression
             TypeError, r'The NameWhitelistProcessor must be passed')
 
     def test_whitelist_param_not_iterable(self):

--- a/pylintrc
+++ b/pylintrc
@@ -383,6 +383,6 @@ ext-import-graph =
 int-import-graph = 
 
 [EXCEPTIONS]
-overgeneral-exceptions = Exception
+overgeneral-exceptions = builtins.Exception
 
 # b045553a1f6a1c84015272c33abea7ecce4ffa93

--- a/setup.py
+++ b/setup.py
@@ -143,6 +143,7 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Django',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def load_requirements(*requirements_paths):
         if seen_spelling is None:
             by_canonical_name[canonical] = package
         elif seen_spelling != package:
-            raise Exception(
+            raise RuntimeError(
                 f'Encountered both "{seen_spelling}" and "{package}" in requirements '
                 'and constraints files; please use just one or the other.'
             )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311, 312}-celery{54}-django{42}
+envlist = py{311, 312}-celery{54}-django{42,52}
 
 [testenv]
 setenv =
@@ -8,6 +8,7 @@ setenv =
 deps =
     celery54: -r{toxinidir}/requirements/celery54.txt
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
     -r{toxinidir}/requirements/test.txt
 commands =
 


### PR DESCRIPTION
- Resolves [Issue](https://github.com/openedx/event-tracking/issues/354)

### Add Django 5.2 Support

This PR updates the codebase to be compatible with Django 5.2 while maintaining compatibility with Django 4.2.

Changes Made:
- Update `ci` and `tox` files
- Ran `django-upgrade` to apply necessary syntax updates for Django 5.2.
- Run tests using `tox` command and resolved the warning 
- Add `changelog`
- Ensured all modifications remain backward-compatible with Django 4.2.

#### django-upgrade usage:

I ran command `git ls-files -z -- '*.py' | xargs -0r django-upgrade --target-version 5.2`