### PR TITLE
fix: create GitHub release with assets attached, not after publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,13 +37,29 @@ jobs:
         git_committer_name: "github-actions"
         git_committer_email: "github-actions@github.com"
         changelog: "false"
+        # Commit, tag, push and build, but don't create the GitHub release.
+        # We create it ourselves in the next step so that the distributions
+        # are attached before the release is published. See that step for why.
+        vcs_release: "false"
 
-    - name: Publish | Upload to GitHub Release Assets
-      uses: python-semantic-release/publish-action@v10.6.1
+    # This repo has immutable releases enabled, which freezes a release's
+    # assets the moment it is published, so assets cannot be attached
+    # afterwards. `gh release create` handles this by creating the release as
+    # a draft, uploading the assets, and only then publishing it:
+    # https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases
+    - name: Publish | Create GitHub Release with Assets
       if: steps.release.outputs.released == 'true'
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ steps.release.outputs.tag }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RELEASE_NOTES: ${{ steps.release.outputs.release_notes }}
+        TAG: ${{ steps.release.outputs.tag }}
+      run: |
+        printf '%s' "$RELEASE_NOTES" > "$RUNNER_TEMP/release_notes.md"
+        gh release create "$TAG" \
+          --verify-tag \
+          --title "$TAG" \
+          --notes-file "$RUNNER_TEMP/release_notes.md" \
+          dist/*
 
     - name: Upload dist artifacts
       if: steps.release.outputs.released == 'true'


### PR DESCRIPTION
Fixes #433. This repo has immutable releases enabled, which freezes a release's assets the moment it's published -- the old flow (main PSR step publishes the release, a separate `publish-action` step attaches assets afterward) can never work under that constraint. That's why v4.1.0's release ended up with zero assets and PyPI never got the upload.

Matches the fix already proven and merged on `openedx/sample-plugin#57`: build without publishing (`vcs_release: false`), then create the release with `dist/*` attached in one `gh release create` call, so assets are in place before the release goes live.

Once merged, this commit's own `fix:` type will trigger a real release (4.0.2 -> 4.1.1) -- the first real end-to-end test of the corrected pipeline, and it naturally backfills the stuck 4.1.0 gap since 4.1.1 will supersede it with a working release.