### PR TITLE
fix: build with uv instead of pip in the uv-run PSR step

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ local_scheme = "no-local-version"
 fallback_version = "0.0.0"
 
 [tool.semantic_release]
-build_command = "python -m pip install --upgrade build && SETUPTOOLS_SCM_PRETEND_VERSION=$NEW_VERSION python -m build"
+build_command = "SETUPTOOLS_SCM_PRETEND_VERSION=$NEW_VERSION uv build"
 major_on_zero = false
 allow_zero_version = true
 tag_format = "v{version}"


### PR DESCRIPTION
#435's uv-based workaround got past the GitPython crash (confirmed: this run correctly computed "The next version is: 4.1.1!") but hit a new failure at the build step: https://github.com/openedx/event-tracking/actions/runs/33071634441

PSR's `build_command` (pyproject.toml) shells out to `python -m pip install --upgrade build`, but `uv`'s ephemeral venvs deliberately don't bundle pip the way a stdlib venv/virtualenv does.

Verified locally through the full real `uvx`-wrapped PSR execution, not just `uv build` standalone: produces the correct `dist/*.tar.gz`/`*.whl` artifacts.