### PR TITLE
fix: restore action SHA-pinning and drop unneeded fetch-depth in CI/release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        fetch-depth: 0
 
     - name: Install uv
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,12 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ github.ref_name }}
-        fetch-depth: 0
 
     - run: git reset --hard ${{ github.sha }}
 
     - name: Python Semantic Release
       id: release
-      uses: python-semantic-release/python-semantic-release@v10.6.2
+      uses: python-semantic-release/python-semantic-release@9a026e9303981c866c3425723009becb2437c757 # v10.6.2
       with:
         github_token: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN }}
         git_committer_name: "github-actions"
@@ -63,21 +62,22 @@ jobs:
 
     - name: Upload dist artifacts
       if: steps.release.outputs.released == 'true'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: dist
         path: dist/
+        if-no-files-found: error
 
   publish_to_pypi:
     runs-on: ubuntu-latest
     needs: release
-    if: needs.release.outputs.released == 'true'
+    if: github.ref_name == 'master' && needs.release.outputs.released == 'true'
     permissions:
       id-token: write
 
     steps:
     - name: Download dist artifacts
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: dist
         path: dist/


### PR DESCRIPTION
## Summary

Follow-up audit of #425 (Python tooling modernization) against this org's
current gold-standard Phase 3 reference (openedx/sample-plugin's
`release.yml`). Found that `release.yml` had drifted from full SHA-pinning
over the course of #425/#434/#435/#436/#438 and picked up two other small
conformance gaps:

- `python-semantic-release/python-semantic-release`, `actions/upload-artifact`,
  and `actions/download-artifact` were on floating tags (`@v10.6.2`, `@v7`,
  `@v8`) instead of pinned commit SHAs. This defeats the point of this repo's
  own prior pin-actions-to-sha effort (#407) for the one workflow that runs
  unreviewed on every push to `master`. Pinned to:
  - `python-semantic-release/python-semantic-release@9a026e9303981c866c3425723009becb2437c757 # v10.6.2`
  - `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1`
  - `actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1`
  All three verified via `gh api repos/<owner>/<repo>/commits/<sha>`, cross-
  checked against their claimed tags.
- Dropped `fetch-depth: 0` from the release job's checkout: python-semantic-
  release deepens a shallow clone itself before evaluating version history,
  so it's never needed there.
- Added `if-no-files-found: error` to the dist upload step, and the
  `github.ref_name == 'master'` guard to `publish_to_pypi`'s `if:`, both
  matching sample-plugin exactly.
- Dropped `fetch-depth: 0` from `ci.yml`'s checkout too: nothing in this
  package reads `__version__` at runtime (no analog to the openedx-events
  `EventData.sourcelib` case), and sample-plugin's own `backend-ci.yml`
  doesn't set it either.

## Test plan

- [ ] CI green on this PR
- [ ] Next merge to `master` exercises the release job with the newly-pinned
      SHAs